### PR TITLE
Fix socket.io connection to use correct property of window.location. …

### DIFF
--- a/src/static/js/view_index.js
+++ b/src/static/js/view_index.js
@@ -25,7 +25,7 @@ $(function () {
     CONFIG.sample_freq = 20;
   } else {
     var socket = window.io.connect(window.location.protocol + '//' +
-                 window.location.host+ ':8080');
+                 window.location.hostname+ ':8080');
   }
 
 


### PR DESCRIPTION
…Fixes OpenROV/openrov-software#436

location.host contains the ":8080" already so if you connect directly to 8080 (as for local development with mocks).