### PR TITLE
Added LiFePO4 batteries & set as default

### DIFF
--- a/src/plugins/capestatus/index.js
+++ b/src/plugins/capestatus/index.js
@@ -88,8 +88,9 @@ function capestatus(name, deps) {
       preferences = {
         batteries: [
           new Battery('TrustFire', 8.0, 13.0)
+          new Battery('LiFePO4', 6.6, 10.9)
         ],
-        selectedBattery: 'TrustFire'
+        selectedBattery: 'LiFePO4'
       };
       config.preferences.set(PREFERENCES, preferences);
     }


### PR DESCRIPTION
Added LiFePO4 batteries and set them as default. Voltages taken from this site: http://www.powerstream.com/LLLF.htm
Lower boundary set a little higher (2.2V rather than 2.0V) in order to have a safety gap.