### PR TITLE
case-sensitive fix for two require

### DIFF
--- a/src/cockpit.js
+++ b/src/cockpit.js
@@ -18,7 +18,7 @@ if (process.env['NODE_PATH']===undefined){ //just in case already been set leave
 var CONFIG = require('./lib/config'), fs = require('fs'), express = require('express'), app = express(), server = require('http').createServer(app), io = require('socket.io').listen(server, { log: false, origins: '*:*' }), EventEmitter = require('events').EventEmitter, OpenROVCamera = require(CONFIG.OpenROVCamera), OpenROVController = require(CONFIG.OpenROVController), logger = require('./lib/logger').create(CONFIG), mkdirp = require('mkdirp'), path = require('path');
 var PluginLoader = require('./lib/PluginLoader');
 var CockpitMessaging = require('./lib/CockpitMessaging');
-var Q=require('Q');
+var Q=require('q');
 require('systemd');
 app.configure(function () {
   app.use(express.static(__dirname + '/static/'));

--- a/src/lib/PluginLoader.js
+++ b/src/lib/PluginLoader.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-var Q =require('Q');
+var Q =require('q');
 
 if (typeof path.existsSync === 'undefined'){
   //forward compatibiltiy to node 12+ from 10. Remove


### PR DESCRIPTION
Tried starting cockpit under Linux, and due the case-sensitive filesystem the 'q' module inclusion failed. I have addressed this in the commits.