### PR TITLE
Correct typo in openrov.service script 

### DIFF
--- a/linux/openrov.service
+++ b/linux/openrov.service
@@ -125,11 +125,10 @@ VERBOSE=yes
 #
 do_start()
 {
-
 	APPLOG_FILE="/var/log/openrov.log"
 	ERRLOG_FILE="/var/log/openrov.err.log"
-	if [ ! -f $APPLOGFILE ];then touch $APPLOG_FILE;fi
-	if [ ! -f $ERRLOGFILE ];then touch $ERRLOG_FILE;fi
+	if [ ! -f $APPLOG_FILE ];then touch $APPLOG_FILE;fi
+	if [ ! -f $ERRLOG_FILE ];then touch $ERRLOG_FILE;fi
 	chown $NODEUSER $APPLOG_FILE
 	chown $NODEUSER $ERRLOG_FILE
 	arg1="1> $APPLOG_FILE"

--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,7 @@ var forever = require('forever-monitor');
 var child = new forever.Monitor('/opt/openrov/cockpit/src/cockpit.js', {
     max: 3,
     silent: process.env.NODE_DEBUG === 'false',
-    options: [],
+    args: [],
     'logFile': '/var/log/openrov.log',
     'outFile': '/var/log/openrov.log',
     'errFile': '/var/log/openrov.log'


### PR DESCRIPTION
Correct typo in openrov.service script  to avoid problem when log files don't exist