### PR TITLE
Broader gamepad support

### DIFF
--- a/src/plugins/blackbox/public/bower.json
+++ b/src/plugins/blackbox/public/bower.json
@@ -24,7 +24,7 @@
     "paper-listbox": "PolymerElements/paper-listbox#^1.1.2"
   },
   "resolutions": {
-    "polymer": "^1.2.1",
+    "polymer": "^1.2.4",
     "webcomponentsjs": "^0.7.2"
   }
 }

--- a/src/plugins/rovpilot/public/js/rovpilot.js
+++ b/src/plugins/rovpilot/public/js/rovpilot.js
@@ -21,6 +21,10 @@
       roll: 0,
       strafe: 0
     };
+    var self=this;
+    this.cockpit.withHistory.on('settings-change.rovpilot',function(settings){
+      self.settings=settings.rovpilot;
+    })
 
   };
 
@@ -236,9 +240,10 @@
     //We can also send our state updates with a timestamp if we figure out a way
     //to deal with the clocks not being in sync between the computer and the ROV.
 
-    this.cockpit.on('settings-change.rovpilot',function(settings){
-      self.settings=settings.rovpilot;
-    })
+    if (this.setting === null){
+      setTimeout(this.listen.bind(this),1000);
+      return;
+    }
 
     //initial sync of state information
     this.rov.emit('plugin.rovpilot.getState', function(state){

--- a/src/static/bower.json
+++ b/src/static/bower.json
@@ -13,7 +13,7 @@
     "polymer": "~1.2.0"
   },
   "resolutions": {
-    "polymer": "^1.1.0",
+    "polymer": "^1.2.1",
     "webcomponentsjs": "0.7.22"
   }
 }

--- a/src/static/js/libs/gamepad.js
+++ b/src/static/js/libs/gamepad.js
@@ -198,7 +198,7 @@
         RIGHT_STICK_Y: 3
       }
     },
-    XBOX: {
+    STANDARD: {
       buttons: {
         A: 0,
         B: 1,
@@ -376,7 +376,7 @@
   Gamepad.prototype._getMapping = function (type) {
     switch (type) {
     case Gamepad.Type.STANDARD:
-      return Gamepad.Mapping.XBOX;
+      return Gamepad.Mapping.STANDARD;
       break;
     case Gamepad.Type.PLAYSTATION:
       if (this.platform === Gamepad.Platform.FIREFOX) {
@@ -400,9 +400,9 @@
       return Gamepad.Mapping.ROCKCANDY;
       break;
     case Gamepad.Type.XBOX:
-      return Gamepad.Mapping.XBOX;
+      return Gamepad.Mapping.STANDARD;
     }
-    return null;
+    return Gamepad.Mapping.STANDARD; //if not found, just use standard
   };
   /**
  * Registers given gamepad.
@@ -411,15 +411,15 @@
  * @return {Boolean} Was connecting the gamepad successful
  */
   Gamepad.prototype._connect = function (gamepad) {
-    gamepad.type = this._resolveControllerType(gamepad.id);
+    gamepad.type = this._resolveControllerType(gamepad);
     if (gamepad.type === Gamepad.Type.UNSUPPORTED) {
       this._fire(Gamepad.Event.UNSUPPORTED, gamepad);
-      return false;
+      //return false;
     }
     gamepad.libmapping = this._getMapping(gamepad.type);
     if (gamepad.libmapping === null) {
       this._fire(Gamepad.Event.UNSUPPORTED, gamepad);
-      return false;
+      //return false;
     }
     gamepad.state = {};
     gamepad.lastState = {};
@@ -461,9 +461,13 @@
  * @param {String} id Controller id
  * @return {String} Controller type, one of Gamepad.Type
  */
-  Gamepad.prototype._resolveControllerType = function (id) {
-    id = id.toLowerCase();
-    if (id.indexOf('rock candy') !== -1) {
+
+Gamepad.prototype._resolveControllerType = function (gamepad) {
+
+    var id = gamepad.id.toLowerCase();
+    if (gamepad.mapping=='standard'){
+      return Gamepad.Type.STANDARD;
+    } else if (id.indexOf('rock candy') !== -1) {
       return Gamepad.Type.ROCKCANDY;
     } else if (id.indexOf('xbox') !== -1 || id.indexOf('360') !== -1 || id.indexOf('standard gamepad') != -1) {
       return Gamepad.Type.XBOX;


### PR DESCRIPTION
All devices that are mapped by the browser vendor will just work.
System falls back to mapping if not mapped (all of the device identity
lookups still need to be updated).  Finally, it no longer prevents
using a gamepad that is cannot map.