### PR TITLE
Add ability to map LED and External Lights to non-linear range

### DIFF
--- a/src/plugins/engineering-panel/public/webcomponents/orov-engineering-button.html
+++ b/src/plugins/engineering-panel/public/webcomponents/orov-engineering-button.html
@@ -134,11 +134,17 @@
                   events: [
                     {message:'plugin.lights.state',fn: function(state){return state.level>0;}}
                   ],
-                  switch: function (state) {
-                    if (self.eventEmitter !== undefined){
-                      var level = 1;
-                      if (state==true) level = 0;
-                      self.eventEmitter.emit('plugin.lights.set',level);
+                  switch: function (state) 
+                  {
+                    if( state == true )
+                    {
+                      // Turn off
+                      self.eventEmitter.emit('plugin.lights.setOnOff', false );
+                    }
+                    else
+                    {
+                      // Turn on to max
+                      self.eventEmitter.emit('plugin.lights.setOnOff', true );
                     }
                   }
                 },
@@ -150,10 +156,18 @@
                     {message:'plugin.externalLights.level',fn: function(lightNum, level){ if( lightNum == 0){ return level > 0; } else{ return null; } }}
                   ],
                   switch: function (state) {
-                    if (self.eventEmitter !== undefined){
-                      var level = 1;
-                      if (state==true) level = 0;
-                      self.eventEmitter.emit('plugin.externalLights.set', 0, level);
+                    if (self.eventEmitter !== undefined)
+                    {
+                      if( state == true )
+                      {
+                        // Turn off
+                        self.eventEmitter.emit('plugin.externalLights.setOnOff', 0, false );
+                      }
+                      else
+                      {
+                        // Turn on to max
+                        self.eventEmitter.emit('plugin.externalLights.setOnOff', 0, true );
+                      }
                     }
                   }
                 },
@@ -165,10 +179,18 @@
                     {message:'plugin.externalLights.level',fn: function(lightNum, level){if( lightNum == 1){ return level > 0; } else{ return null; } } }
                   ],
                   switch: function (state) {
-                    if (self.eventEmitter !== undefined){
-                      var level = 1;
-                      if (state==true) level = 0;
-                      self.eventEmitter.emit('plugin.externalLights.set', 1, level);
+                    if (self.eventEmitter !== undefined)
+                    {
+                      if( state == true )
+                      {
+                        // Turn off
+                        self.eventEmitter.emit('plugin.externalLights.setOnOff', 1, false );
+                      }
+                      else
+                      {
+                        // Turn on to max
+                        self.eventEmitter.emit('plugin.externalLights.setOnOff', 1, true );
+                      }
                     }
                   }
                 },

--- a/src/plugins/externallights/firmware/CExternalLights.cpp
+++ b/src/plugins/externallights/firmware/CExternalLights.cpp
@@ -47,10 +47,6 @@ void CExternalLights::Update( CCommand& commandIn )
 		Serial.print( F( "LIGTE0:" ) );
 		Serial.print( value );
 		Serial.print( ';' );
-		
-		Serial.print( F( "LIGPE0:" ) );
-		Serial.print( value );
-		Serial.println( ';' );
 	}
     
     // Handle messages
@@ -74,10 +70,6 @@ void CExternalLights::Update( CCommand& commandIn )
 		Serial.print( F( "LIGTE1:" ) );
 		Serial.print( value );
 		Serial.print( ';' );
-		
-		Serial.print( F( "LIGPE1:" ) );
-		Serial.print( value );
-		Serial.println( ';' );
 	}
 }
 

--- a/src/plugins/externallights/firmware/CExternalLights.cpp
+++ b/src/plugins/externallights/firmware/CExternalLights.cpp
@@ -49,7 +49,7 @@ void CExternalLights::Update( CCommand& commandIn )
 		Serial.print( ';' );
 		
 		Serial.print( F( "LIGPE0:" ) );
-		Serial.print( percentValue );
+		Serial.print( value );
 		Serial.println( ';' );
 	}
     
@@ -76,7 +76,7 @@ void CExternalLights::Update( CCommand& commandIn )
 		Serial.print( ';' );
 		
 		Serial.print( F( "LIGPE1:" ) );
-		Serial.print( percentValue );
+		Serial.print( value );
 		Serial.println( ';' );
 	}
 }

--- a/src/plugins/externallights/firmware/CExternalLights.cpp
+++ b/src/plugins/externallights/firmware/CExternalLights.cpp
@@ -29,8 +29,18 @@ void CExternalLights::Update( CCommand& commandIn )
 {
     if( commandIn.Equals( "elight0" ) )
 	{
-		float percentValue = ( float )commandIn.m_arguments[1] / 100.0f;
-		int value = (int)( 255.0f * percentValue );
+		// Should be between 0-255, with 255 being full brightness
+		int value = commandIn.m_arguments[1];
+
+		// Bounds corrections
+		if( value < 0 )
+		{
+			value = 0;
+		}
+		if( value > 255 )
+		{
+			value = 255;
+		}
 		
 		elight0.Write( value );
 		
@@ -46,16 +56,25 @@ void CExternalLights::Update( CCommand& commandIn )
     // Handle messages
 	if( commandIn.Equals( "elight1" ) )
 	{
-		// 0 - 255
-		float percentValue = ( float )commandIn.m_arguments[1] / 100.0f; //0 - 255
-		int value = (int)( 255.0f * percentValue );
+		// Should be between 0-255, with 255 being full brightness
+		int value = commandIn.m_arguments[1];
+
+		// Bounds corrections
+		if( value < 0 )
+		{
+			value = 0;
+		}
+		if( value > 255 )
+		{
+			value = 255;
+		}
 		
 		elight1.Write( value );
-
+		
 		Serial.print( F( "LIGTE1:" ) );
 		Serial.print( value );
 		Serial.print( ';' );
-
+		
 		Serial.print( F( "LIGPE1:" ) );
 		Serial.print( percentValue );
 		Serial.println( ';' );

--- a/src/plugins/externallights/index.js
+++ b/src/plugins/externallights/index.js
@@ -8,7 +8,7 @@ function ExternalLights(name, deps)
     self.settings        = [ 0, 0 ];
 
     //  Settings:       = [ 0 .. 5 ]
-    self.levelMap        = [ 0, 0.0625, 0.125, 0.25, 0.5, 1.0 ];
+    self.levelMap        = [ 0, 16, 32, 64, 128, 255 ];
 
     // Cockpit
     deps.cockpit.on('plugin.externalLights.toggle', function( lightNum ) 

--- a/src/plugins/externallights/index.js
+++ b/src/plugins/externallights/index.js
@@ -48,7 +48,7 @@ function ExternalLights(name, deps)
         if ('LIGTE0' in data) 
         {
             // Value of 0-255 representing percent
-            var level = data.LIGTE0;
+            var level = parseInt( data.LIGTE0 );
 
             console.log( "External light 0 status: " + level );
 
@@ -81,7 +81,7 @@ function ExternalLights(name, deps)
         else if ('LIGTE1' in data) 
         {
             // Value of 0-255 representing percent
-            var level = data.LIGTE1;
+            var level = parseInt( data.LIGTE1 );
 
             console.log( "External light 1 status: " + level );
 

--- a/src/plugins/externallights/index.js
+++ b/src/plugins/externallights/index.js
@@ -44,10 +44,10 @@ function ExternalLights(name, deps)
     // Arduino
     deps.globalEventLoop.on( 'mcu.status', function (data) 
     {   
-        if ('LIGPE0' in data) 
+        if ('LIGTE0' in data) 
         {
             // Value of 0-255 representing percent
-            var level = data.LIGPE0;
+            var level = data.LIGTE0;
 
             console.log( "External light 0 status: " + level );
 
@@ -73,10 +73,10 @@ function ExternalLights(name, deps)
 
             deps.cockpit.emit( 'plugin.externalLights.state', 0, { level: self.settings[ 0 ] } );
         }
-        else if ('LIGPE1' in data) 
+        else if ('LIGTE1' in data) 
         {
             // Value of 0-255 representing percent
-            var level = data.LIGPE1;
+            var level = data.LIGTE1;
 
             console.log( "External light 1 status: " + level );
 
@@ -93,7 +93,7 @@ function ExternalLights(name, deps)
                 // Find the closest level in our map
                 var closest = self.levelMap.reduce( function (prev, curr) 
                 {
-                    return (Math.abs(curr - goal) < Math.abs(prev - goal) ? curr : prev);
+                    return (Math.abs(curr - level) < Math.abs(prev - level) ? curr : prev);
                 });
                 
                 // Set the new setting value based on the index of the closest level

--- a/src/plugins/externallights/index.js
+++ b/src/plugins/externallights/index.js
@@ -9,6 +9,7 @@ function ExternalLights(name, deps)
 
     //  Settings:       = [ 0 .. 5 ]
     self.levelMap        = [ 0, 16, 32, 64, 128, 255 ];
+    self.maxLevel        = self.levelMap.length - 1;
 
     // Cockpit
     deps.cockpit.on('plugin.externalLights.toggle', function( lightNum ) 
@@ -31,7 +32,7 @@ function ExternalLights(name, deps)
         if( setOn )
         {
             // Max light power
-            setLights( lightNum, self.levelMap.length );
+            setLights( lightNum, self.maxLevel );
         }
         else
         {
@@ -124,7 +125,7 @@ function ExternalLights(name, deps)
         else 
         {
             // Set to max power
-            setLights( lightNum, self.levelMap.length );
+            setLights( lightNum, self.maxLevel );
         }
     };
 
@@ -137,9 +138,9 @@ function ExternalLights(name, deps)
         {
             value = 0;
         }
-        else if( value >= self.levelMap.length )
+        else if( value >= self.maxLevel )
         {
-            value = self.levelMap.length;
+            value = self.maxLevel;
         }
         
         // Make sure the new setting is an integer

--- a/src/plugins/externallights/index.js
+++ b/src/plugins/externallights/index.js
@@ -62,7 +62,7 @@ function ExternalLights(name, deps)
                 // Find the closest level in our map
                 var closest = self.levelMap.reduce( function (prev, curr) 
                 {
-                    return (Math.abs(curr - goal) < Math.abs(prev - goal) ? curr : prev);
+                    return (Math.abs(curr - level) < Math.abs(prev - level) ? curr : prev);
                 });
                 
                 // Set the new setting value based on the index of the closest level

--- a/src/plugins/externallights/index.js
+++ b/src/plugins/externallights/index.js
@@ -58,6 +58,8 @@ function ExternalLights(name, deps)
             {
                 // The new setting value is the array index of the level in the level map, if it exists
                 self.settings[ 0 ] = setting;
+
+                console.log( "External light 0 setting: " + setting );
             }
             else
             {
@@ -69,6 +71,8 @@ function ExternalLights(name, deps)
                 
                 // Set the new setting value based on the index of the closest level
                 self.settings[ 0 ] = self.levelMap.indexOf( closest );
+
+                console.log( "External light 0 closest setting: " + self.settings[ 0 ] );
             }
 
             deps.cockpit.emit( 'plugin.externalLights.state', 0, { level: self.settings[ 0 ] } );

--- a/src/plugins/externallights/index.js
+++ b/src/plugins/externallights/index.js
@@ -43,11 +43,13 @@ function ExternalLights(name, deps)
 
     // Arduino
     deps.globalEventLoop.on( 'mcu.status', function (data) 
-    {
+    {   
         if ('LIGPE0' in data) 
         {
             // Value of 0-255 representing percent
             var level = data.LIGPE0;
+
+            console.log( "External light 0 status: " + level );
 
             // Search for the level in the level map
             var setting = self.levelMap.indexOf( level );
@@ -75,6 +77,8 @@ function ExternalLights(name, deps)
         {
             // Value of 0-255 representing percent
             var level = data.LIGPE1;
+
+            console.log( "External light 1 status: " + level );
 
             // Search for the level in the level map
             var setting = self.levelMap.indexOf( level );
@@ -122,6 +126,8 @@ function ExternalLights(name, deps)
 
     var setLights = function setLights( lightNum, value ) 
     {
+        console.log( "Attemping to set lights [" + lightNum + "] to: " + value );
+
         // Range limit the new setting from 0 to the max number of defined levels
         if( value < 0 )
         {
@@ -134,6 +140,8 @@ function ExternalLights(name, deps)
         
         // Make sure the new setting is an integer
         self.settings[ lightNum ] = Math.round( value );
+
+        console.log( "Setting lights [" + lightNum + "] to: " + self.settings[ lightNum ] );
 
         var command = 'elight' + lightNum +'(' + self.levelMap[ self.settings[ lightNum ] ] + ')';
 

--- a/src/plugins/externallights/public/js/externallights.js
+++ b/src/plugins/externallights/public/js/externallights.js
@@ -3,16 +3,18 @@
   'use strict';
   var plugins = namespace('plugins');
   
-  plugins.ExternalLights = function(cockpit) {
-    var self = this;
-    self.cockpit = cockpit;
-    self.state = [ {}, {} ];
+  plugins.ExternalLights = function(cockpit) 
+  {
+    var self      = this;
+    self.cockpit  = cockpit;
+    self.state    = [ {}, {} ];
   };
 
-  plugins.ExternalLights.prototype.getTelemetryDefintions = function getTelemetryDefintions() {
+  plugins.ExternalLights.prototype.getTelemetryDefintions = function getTelemetryDefintions() 
+  {
     return([
-      {name: 'LIGPE0', description: 'External Light 0 percent power'},
-      {name: 'LIGPE1', description: 'External Light 1 percent power'}
+      { name: 'LIGPE0', description: 'External Light 0 percent power' },
+      { name: 'LIGPE1', description: 'External Light 1 percent power' }
     ]);
   }
 
@@ -27,24 +29,27 @@ plugins.ExternalLights.prototype.inputDefaults = function ()
       name: 'plugin.externalLights.0.adjust_increment',
       description: 'Makes the ROV lights brighter.',
       defaults: { keyboard: '6'},
-      down: function () {
-        cockpit.rov.emit('plugin.externalLights.set', 0, 0.1+ Number.parseFloat(self.state[0].level));
+      down: function () 
+      {
+        cockpit.rov.emit( 'plugin.externalLights.set', 0, self.state[0].level + 1 );
       }
     },
     {
       name: 'plugin.externalLights.0.adjust_decrememt',
       description: 'Makes the ROV lights dimmer.',
       defaults: { keyboard: '7'},
-      down: function () {
-        cockpit.rov.emit('plugin.externalLights.set', 0, -0.1 + Number.parseFloat(self.state[0].level));
+      down: function () 
+      {
+        cockpit.rov.emit( 'plugin.externalLights.set', 0, self.state[0].level - 1 );
       }
     },
     {
       name: 'plugin.externalLights.0.toggle',
       description: 'Toggles the ROV lights on/off.',
       defaults: { keyboard: '8' },
-      down: function () {
-        cockpit.rov.emit('plugin.externalLights.toggle', 0);
+      down: function () 
+      {
+        cockpit.rov.emit( 'plugin.externalLights.toggle', 0 );
       }
     },
     
@@ -53,8 +58,9 @@ plugins.ExternalLights.prototype.inputDefaults = function ()
       name: 'plugin.externalLights.1.adjust_increment',
       description: 'Makes the ROV lights brighter.',
       defaults: { keyboard: '9'},
-      down: function () {
-        cockpit.rov.emit('plugin.externalLights.set', 1, 0.1+ Number.parseFloat(self.state[1].level));
+      down: function () 
+      {
+        cockpit.rov.emit('plugin.externalLights.set', 1, self.state[1].level + 1 );
       }
     },
     {
@@ -62,36 +68,38 @@ plugins.ExternalLights.prototype.inputDefaults = function ()
       description: 'Makes the ROV lights dimmer.',
       defaults: { keyboard: '0'},
 
-      down: function () {
-        cockpit.rov.emit('plugin.externalLights.set', 1, -0.1 + Number.parseFloat(self.state[1].level));
+      down: function () 
+      {
+        cockpit.rov.emit('plugin.externalLights.set', 1, self.state[1].level - 1);
       }
     },
     {
       name: 'plugin.externalLights.1.toggle',
       description: 'Toggles the ROV lights on/off.',
       defaults: { keyboard: '-' },
-      down: function () {
+      down: function () 
+      {
         cockpit.rov.emit('plugin.externalLights.toggle', 1);
       }
     }
   ]
 }
 
-  //This pattern will hook events in the cockpit and pull them all back
-  //so that the reference to this instance is available for further processing
+  // This pattern will hook events in the cockpit and pull them all back
+  // so that the reference to this instance is available for further processing
   plugins.ExternalLights.prototype.listen = function listen() 
   {
     var self = this;
 
       self.cockpit.rov.withHistory.on('plugin.externalLights.state', function(lightNum, state) 
       {
-        self.cockpit.emit('plugin.externalLights.level', lightNum, state.level);
+        self.cockpit.emit('plugin.externalLights.level', lightNum, state.level );
         self.state[ lightNum ]  = state;
       });
 
-      self.cockpit.on('plugin.externalLights.set',function(lightNum, value)
+      self.cockpit.on('plugin.externalLights.set',function( lightNum, value )
       {
-          cockpit.rov.emit('plugin.externalLights.set',lightNum, value);
+          cockpit.rov.emit('plugin.externalLights.set', lightNum, value );
       });
 
   };

--- a/src/plugins/externallights/public/js/externallights.js
+++ b/src/plugins/externallights/public/js/externallights.js
@@ -28,7 +28,7 @@ plugins.ExternalLights.prototype.inputDefaults = function ()
     {
       name: 'plugin.externalLights.0.adjust_increment',
       description: 'Makes the ROV lights brighter.',
-      defaults: { keyboard: '6'},
+      defaults: { keyboard: '8'},
       down: function () 
       {
         cockpit.rov.emit( 'plugin.externalLights.set', 0, self.state[0].level + 1 );
@@ -46,7 +46,7 @@ plugins.ExternalLights.prototype.inputDefaults = function ()
     {
       name: 'plugin.externalLights.0.toggle',
       description: 'Toggles the ROV lights on/off.',
-      defaults: { keyboard: '8' },
+      defaults: { keyboard: '6' },
       down: function () 
       {
         cockpit.rov.emit( 'plugin.externalLights.toggle', 0 );
@@ -57,7 +57,7 @@ plugins.ExternalLights.prototype.inputDefaults = function ()
     {
       name: 'plugin.externalLights.1.adjust_increment',
       description: 'Makes the ROV lights brighter.',
-      defaults: { keyboard: '9'},
+      defaults: { keyboard: '-'},
       down: function () 
       {
         cockpit.rov.emit('plugin.externalLights.set', 1, self.state[1].level + 1 );
@@ -76,7 +76,7 @@ plugins.ExternalLights.prototype.inputDefaults = function ()
     {
       name: 'plugin.externalLights.1.toggle',
       description: 'Toggles the ROV lights on/off.',
-      defaults: { keyboard: '-' },
+      defaults: { keyboard: '9' },
       down: function () 
       {
         cockpit.rov.emit('plugin.externalLights.toggle', 1);

--- a/src/plugins/externallights/public/js/externallights.js
+++ b/src/plugins/externallights/public/js/externallights.js
@@ -7,7 +7,7 @@
   {
     var self      = this;
     self.cockpit  = cockpit;
-    self.state    = [ {}, {} ];
+    //self.state    = [ {}, {} ];
   };
 
   plugins.ExternalLights.prototype.getTelemetryDefintions = function getTelemetryDefintions() 
@@ -31,7 +31,8 @@ plugins.ExternalLights.prototype.inputDefaults = function ()
       defaults: { keyboard: '8'},
       down: function () 
       {
-        cockpit.rov.emit( 'plugin.externalLights.set', 0, self.state[0].level + 1 );
+        //cockpit.rov.emit( 'plugin.externalLights.set', 0, self.state[0].level + 1 );
+        cockpit.rov.emit( 'plugin.externalLights.adjust', 0, 1 );
       }
     },
     {
@@ -40,7 +41,8 @@ plugins.ExternalLights.prototype.inputDefaults = function ()
       defaults: { keyboard: '7'},
       down: function () 
       {
-        cockpit.rov.emit( 'plugin.externalLights.set', 0, self.state[0].level - 1 );
+        //cockpit.rov.emit( 'plugin.externalLights.set', 0, self.state[0].level - 1 );
+        cockpit.rov.emit( 'plugin.externalLights.adjust', 0, -1 );
       }
     },
     {
@@ -60,7 +62,8 @@ plugins.ExternalLights.prototype.inputDefaults = function ()
       defaults: { keyboard: '-'},
       down: function () 
       {
-        cockpit.rov.emit('plugin.externalLights.set', 1, self.state[1].level + 1 );
+        //cockpit.rov.emit('plugin.externalLights.set', 1, self.state[1].level + 1 );
+        cockpit.rov.emit('plugin.externalLights.adjust', 1, 1 );
       }
     },
     {
@@ -70,7 +73,8 @@ plugins.ExternalLights.prototype.inputDefaults = function ()
 
       down: function () 
       {
-        cockpit.rov.emit('plugin.externalLights.set', 1, self.state[1].level - 1);
+        //cockpit.rov.emit('plugin.externalLights.set', 1, self.state[1].level - 1);
+        cockpit.rov.emit('plugin.externalLights.adjust', 1, -1 );
       }
     },
     {
@@ -94,12 +98,12 @@ plugins.ExternalLights.prototype.inputDefaults = function ()
       self.cockpit.rov.withHistory.on('plugin.externalLights.state', function(lightNum, state) 
       {
         self.cockpit.emit('plugin.externalLights.level', lightNum, state.level );
-        self.state[ lightNum ]  = state;
+        //self.state[ lightNum ]  = state;
       });
 
-      self.cockpit.on('plugin.externalLights.set',function( lightNum, value )
+      self.cockpit.on('plugin.externalLights.adjust',function( lightNum, value )
       {
-          cockpit.rov.emit('plugin.externalLights.set', lightNum, value );
+          cockpit.rov.emit('plugin.externalLights.adjust', lightNum, value );
       });
 
   };

--- a/src/plugins/lights/index.js
+++ b/src/plugins/lights/index.js
@@ -56,6 +56,8 @@
             {
                 // The new setting value is the array index of the level in the level map, if it exists
                 self.setting = setting;
+
+                console.log( "A: " + self.setting );
             }
             else
             {
@@ -67,6 +69,8 @@
                 
                 // Set the new setting value based on the index of the closest level
                 self.setting = self.levelMap.indexOf( closest );
+
+                console.log( "B: " + self.setting );
             }
 
             deps.cockpit.emit( 'plugin.lights.state', { level: self.setting } );
@@ -76,6 +80,9 @@
      var adjustLights = function adjustLights( value ) 
     {
         // Modify current setting
+        console.log( "C: " + ( self.setting + value ) );
+        console.log( "D: " + value );
+
         setLights( self.setting + value );
     };
 
@@ -95,6 +102,8 @@
 
     var setLights = function setLights( value ) 
     {
+        console.log( "E: " + value );
+
         // Range limit the new setting from 0 to the max number of defined levels
         if( value < 0 )
         {
@@ -109,6 +118,8 @@
         self.setting = Math.round( value );
 
         var command = 'ligt(' + self.levelMap[ self.setting ] + ')';
+
+        console.log( "F: " + self.setting );
 
         deps.globalEventLoop.emit( 'mcu.SendCommand', command );
     };

--- a/src/plugins/lights/index.js
+++ b/src/plugins/lights/index.js
@@ -1,72 +1,121 @@
 (function() {
-  function Lights(name, deps) {
+  function Lights(name, deps) 
+  {
     console.log('Lights plugin loaded');
-    var lights = 0;
-    var ArduinoHelper = require('../../lib/ArduinoHelper')();
+
+    var self            = this;
+
+    self.setting        = 0;
+
+    //  Settings:       = [ 0 .. 5 ]
+    self.levelMap        = [ 0, 48, 64, 96, 160, 255 ];
+    self.maxLevel        = self.levelMap.length - 1;
 
     // Cockpit
-    deps.cockpit.on('plugin.lights.toggle', function () {
-      toggleLights();
+    deps.cockpit.on('plugin.lights.toggle', function() 
+    {
+        toggleLights();
     });
 
-    deps.cockpit.on('plugin.lights.adjust', function (value) {
-      adjustLights(value);
+    deps.cockpit.on('plugin.lights.adjust', function( value ) 
+    {
+        adjustLights( value );
     });
 
-    deps.cockpit.on('plugin.lights.set', function (value) {
-      setLights(value);
+    deps.cockpit.on('plugin.lights.set', function( value ) 
+    {
+        setLights( value );
+    });
+
+    deps.cockpit.on('plugin.lights.setOnOff', function( setOn ) 
+    {
+        if( setOn )
+        {
+            // Max light power
+            setLights( self.maxLevel );
+        }
+        else
+        {
+            // Min light power
+            setLights( 0 );
+        }
     });
 
     // Arduino
-    deps.globalEventLoop.on( 'mcu.status', function (data) {
-      if ('LIGP' in data) {
-        //value of 0-1.0 representing percent
-        var level = data.LIGP;
-        deps.cockpit.emit('plugin.lights.state', {level:level});
-      }
+    deps.globalEventLoop.on( 'mcu.status', function (data) 
+    {   
+        if ('LIGT' in data) 
+        {
+            // Value of 0-255 representing percent
+            var level = parseInt( data.LIGT );
+
+            // Search for the level in the level map
+            var setting = self.levelMap.indexOf( level );
+
+            if( setting != -1 )
+            {
+                // The new setting value is the array index of the level in the level map, if it exists
+                self.setting = setting;
+            }
+            else
+            {
+                // Find the closest level in our map
+                var closest = self.levelMap.reduce( function (prev, curr) 
+                {
+                    return (Math.abs(curr - level) < Math.abs(prev - level) ? curr : prev);
+                });
+                
+                // Set the new setting value based on the index of the closest level
+                self.setting = self.levelMap.indexOf( closest );
+            }
+
+            deps.cockpit.emit( 'plugin.lights.state', { level: self.setting } );
+        }
     });
 
-    var adjustLights = function (value) {
-      if (lights === 0 && value < 0) {
-        //this code rounds the horn so to speak by jumping from zero to max and vise versa
-        lights = 0;  //disabled the round the horn feature
-      } else if (lights == 1 && value > 0) {
-        lights = 1;  //disabled the round the horn feature
-      } else {
-        lights += value;
-      }
-      setLights(lights);
-    };
-
-    var toggleLights = function() {
-      if (lights > 0) {
-        setLights(0);
-      } else {
-        setLights(1);
-      }
-    };
-
-    var setLights = function (value) 
+     var adjustLights = function adjustLights( value ) 
     {
-      lights = value;
-      
-      if (lights >= 1)
-      {
-        lights = 1;
-      }
-      
-      if (lights <= 0)
-      {
-        lights = 0;
-      }
-
-      var command = 'ligt(' + ArduinoHelper.serial.packPercent(lights) + ')';
-      deps.globalEventLoop.emit( 'mcu.SendCommand', command);
-
+        // Modify current setting
+        setLights( self.setting + value );
     };
 
+    var toggleLights = function toggleLights() 
+    {
+        if( self.setting > 0 ) 
+        {
+            // Set to min power
+            setLights( 0 );
+        } 
+        else 
+        {
+            // Set to max power
+            setLights( self.maxLevel );
+        }
+    };
+
+    var setLights = function setLights( value ) 
+    {
+        // Range limit the new setting from 0 to the max number of defined levels
+        if( value < 0 )
+        {
+            value = 0;
+        }
+        else if( value >= self.maxLevel )
+        {
+            value = self.maxLevel;
+        }
+        
+        // Make sure the new setting is an integer
+        self.setting = Math.round( value );
+
+        var command = 'ligt' + lightNum +'(' + self.levelMap[ self.setting ] + ')';
+
+        deps.globalEventLoop.emit( 'mcu.SendCommand', command );
+    };
   }
-  module.exports = function (name, deps) {
+
+  module.exports = function (name, deps) 
+  {
     return new Lights(name,deps);
   };
 

--- a/src/plugins/lights/index.js
+++ b/src/plugins/lights/index.js
@@ -108,7 +108,7 @@
         // Make sure the new setting is an integer
         self.setting = Math.round( value );
 
-        var command = 'ligt' + lightNum +'(' + self.levelMap[ self.setting ] + ')';
+        var command = 'ligt(' + self.levelMap[ self.setting ] + ')';
 
         deps.globalEventLoop.emit( 'mcu.SendCommand', command );
     };

--- a/src/plugins/lights/index.js
+++ b/src/plugins/lights/index.js
@@ -8,7 +8,7 @@
     self.setting        = 0;
 
     //  Settings:       = [ 0 .. 5 ]
-    self.levelMap        = [ 0, 48, 64, 96, 160, 255 ];
+    self.levelMap        = [ 0, 80, 100, 130, 190, 255 ];
     self.maxLevel        = self.levelMap.length - 1;
 
     // Cockpit
@@ -56,8 +56,6 @@
             {
                 // The new setting value is the array index of the level in the level map, if it exists
                 self.setting = setting;
-
-                console.log( "A: " + self.setting );
             }
             else
             {
@@ -69,8 +67,6 @@
                 
                 // Set the new setting value based on the index of the closest level
                 self.setting = self.levelMap.indexOf( closest );
-
-                console.log( "B: " + self.setting );
             }
 
             deps.cockpit.emit( 'plugin.lights.state', { level: self.setting } );
@@ -80,9 +76,6 @@
      var adjustLights = function adjustLights( value ) 
     {
         // Modify current setting
-        console.log( "C: " + ( self.setting + value ) );
-        console.log( "D: " + value );
-
         setLights( self.setting + value );
     };
 
@@ -102,8 +95,6 @@
 
     var setLights = function setLights( value ) 
     {
-        console.log( "E: " + value );
-
         // Range limit the new setting from 0 to the max number of defined levels
         if( value < 0 )
         {
@@ -118,8 +109,6 @@
         self.setting = Math.round( value );
 
         var command = 'ligt(' + self.levelMap[ self.setting ] + ')';
-
-        console.log( "F: " + self.setting );
 
         deps.globalEventLoop.emit( 'mcu.SendCommand', command );
     };

--- a/src/plugins/lights/public/js/lights.js
+++ b/src/plugins/lights/public/js/lights.js
@@ -62,6 +62,7 @@
     self.cockpit.rov.withHistory.on('plugin.lights.state', function(state) 
     {
       self.cockpit.emit('plugin.lights.level', state.level );
+      self.state = state;
     });
 
     self.cockpit.on('plugin.lights.set',function(value)

--- a/src/plugins/lights/public/js/lights.js
+++ b/src/plugins/lights/public/js/lights.js
@@ -17,6 +17,8 @@
 
   plugins.Lights.prototype.inputDefaults = function inputDefaults() 
   {
+    var self = this;
+
     return [
       // lights increment
       {

--- a/src/plugins/lights/public/js/lights.js
+++ b/src/plugins/lights/public/js/lights.js
@@ -1,25 +1,31 @@
-(function(window) {
+(function(window) 
+{
   'use strict';
   var plugins = namespace('plugins');
-  plugins.Lights = function(cockpit) {
-    var self = this;
-    self.cockpit = cockpit;
 
+  plugins.Lights = function(cockpit)
+  {
+    var self      = this;
+    self.cockpit  = cockpit;
+    self.state    = {};
   };
 
-  plugins.Lights.prototype.getTelemetryDefintions = function getTelemetryDefintions() {
-    return([{name: 'LIGP', description: 'Internal lights percent of power'}]);
+  plugins.Lights.prototype.getTelemetryDefintions = function getTelemetryDefintions() 
+  {
+    return( [{name: 'LIGP', description: 'Internal lights percent of power'}] );
   }
 
-  plugins.Lights.prototype.inputDefaults = function inputDefaults() {
+  plugins.Lights.prototype.inputDefaults = function inputDefaults() 
+  {
     return [
       // lights increment
       {
         name: 'plugin.lights.adjust_increment',
         description: 'Makes the ROV lights brighter.',
         defaults: { keyboard: 'p', gamepad: 'DPAD_UP' },
-        down: function () {
-          cockpit.rov.emit('plugin.lights.adjust', 0.1);
+        down: function () 
+        {
+          cockpit.rov.emit('plugin.lights.adjust', self.state.level + 1 );
         }
       },
 
@@ -29,8 +35,9 @@
         description: 'Makes the ROV lights dimmer.',
         defaults: { keyboard: 'o', gamepad: 'DPAD_DOWN' },
 
-        down: function () {
-          cockpit.rov.emit('plugin.lights.adjust', -0.1);
+        down: function () 
+        {
+          cockpit.rov.emit('plugin.lights.adjust', self.state.level -1 );
         }
       },
 
@@ -39,12 +46,12 @@
         name: 'plugin.lights.toggle',
         description: 'Toggles the ROV lights on/off.',
         defaults: { keyboard: 'i' },
-        down: function () {
+        down: function () 
+        {
           cockpit.rov.emit('plugin.lights.toggle');
         }
       }
-    ]
-
+    ];
   };
 
   //This pattern will hook events in the cockpit and pull them all back
@@ -52,11 +59,13 @@
   plugins.Lights.prototype.listen = function listen() {
     var self = this;
 
-    self.cockpit.rov.withHistory.on('plugin.lights.state', function(state) {
-      self.cockpit.emit('plugin.lights.state',state);
+    self.cockpit.rov.withHistory.on('plugin.lights.state', function(state) 
+    {
+      self.cockpit.emit('plugin.lights.level', state.level );
     });
 
-    self.cockpit.on('plugin.lights.set',function(value){
+    self.cockpit.on('plugin.lights.set',function(value)
+    {
         cockpit.rov.emit('plugin.lights.set',value);
     });
 

--- a/src/plugins/lights/public/js/lights.js
+++ b/src/plugins/lights/public/js/lights.js
@@ -26,7 +26,7 @@
         defaults: { keyboard: 'p', gamepad: 'DPAD_UP' },
         down: function () 
         {
-          cockpit.rov.emit('plugin.lights.set', 1 );
+          cockpit.rov.emit('plugin.lights.adjust', 1 );
         }
       },
 

--- a/src/plugins/lights/public/js/lights.js
+++ b/src/plugins/lights/public/js/lights.js
@@ -7,7 +7,6 @@
   {
     var self      = this;
     self.cockpit  = cockpit;
-    self.state    = {};
   };
 
   plugins.Lights.prototype.getTelemetryDefintions = function getTelemetryDefintions() 
@@ -27,7 +26,7 @@
         defaults: { keyboard: 'p', gamepad: 'DPAD_UP' },
         down: function () 
         {
-          cockpit.rov.emit('plugin.lights.adjust', self.state.level + 1 );
+          cockpit.rov.emit('plugin.lights.set', 1 );
         }
       },
 
@@ -39,7 +38,7 @@
 
         down: function () 
         {
-          cockpit.rov.emit('plugin.lights.adjust', self.state.level -1 );
+          cockpit.rov.emit('plugin.lights.adjust', -1 );
         }
       },
 
@@ -64,12 +63,11 @@
     self.cockpit.rov.withHistory.on('plugin.lights.state', function(state) 
     {
       self.cockpit.emit('plugin.lights.level', state.level );
-      self.state = state;
     });
 
-    self.cockpit.on('plugin.lights.set',function(value)
+    self.cockpit.on('plugin.lights.adjust',function(value)
     {
-        cockpit.rov.emit('plugin.lights.set',value);
+        cockpit.rov.emit('plugin.lights.adjust',value);
     });
 
   };

--- a/src/plugins/mobile-ui/public/webcomponents/settings-menu/settings-menu.html
+++ b/src/plugins/mobile-ui/public/webcomponents/settings-menu/settings-menu.html
@@ -179,14 +179,16 @@
 					if( e.detail.active )
 					{
 						console.log( "turning lights on" );
-						this.eventEmitter.emit( 'plugin.lights.set', 1 );
-						this.eventEmitter.emit( 'plugin.externalLights.set', 1 );
+						this.eventEmitter.emit( 'plugin.lights.setOnOff', true );
+						this.eventEmitter.emit( 'plugin.externalLights.setOnOff', 0, true );
+						this.eventEmitter.emit( 'plugin.externalLights.setOnOff', 1, true );
 					}
 					else
 					{
 						console.log( "turning lights off" );
-						this.eventEmitter.emit( 'plugin.lights.set', 0 );
-						this.eventEmitter.emit( 'plugin.externalLights.set', 1 );
+						this.eventEmitter.emit( 'plugin.lights.setOnOff', 0 );
+						this.eventEmitter.emit( 'plugin.externalLights.setOnOff', 0, false );
+						this.eventEmitter.emit( 'plugin.externalLights.setOnOff', 1, false );
 					}
 				},
 

--- a/src/plugins/new-ui/public/webcomponents/switches.html
+++ b/src/plugins/new-ui/public/webcomponents/switches.html
@@ -140,14 +140,20 @@
                   state: false,
                   description: 'LED lights on/off',
                   events: [
-                    {message:'plugin.lights.state',fn: function(state){return state.level>0;}}
+                    {message:'plugin.lights.level',fn: function(level){return level > 0; }}
                   ],
-                  switch: function (state) {
-                    if (self.eventEmitter !== undefined){
-                      var level = 1;
-                      if (state==true) level = 0;
-                      self.eventEmitter.emit('plugin.lights.set',level);
-                    }
+                  switch: function (state) 
+                  {
+                   if( state == true )
+                      {
+                        // Turn off
+                        self.eventEmitter.emit('plugin.lights.setOnOff', false );
+                      }
+                      else
+                      {
+                        // Turn on to max
+                        self.eventEmitter.emit('plugin.lights.setOnOff', true );
+                      }
                   }
                 },
                 XL0: {

--- a/src/plugins/new-ui/public/webcomponents/switches.html
+++ b/src/plugins/new-ui/public/webcomponents/switches.html
@@ -157,11 +157,20 @@
                   events: [
                     {message:'plugin.externalLights.level',fn: function(lightNum, level){ if( lightNum == 0){ return level > 0; } else{ return null; } }}
                   ],
-                  switch: function (state) {
-                    if (self.eventEmitter !== undefined){
-                      var level = 1;
-                      if (state==true) level = 0;
-                      self.eventEmitter.emit('plugin.externalLights.set', 0, level);
+                  switch: function (state) 
+                  {
+                    if (self.eventEmitter !== undefined)
+                    {
+                      if( state == true )
+                      {
+                        // Turn off
+                        self.eventEmitter.emit('plugin.externalLights.setOnOff', 0, false );
+                      }
+                      else
+                      {
+                        // Turn on to max
+                        self.eventEmitter.emit('plugin.externalLights.setOnOff', 0, true );
+                      }
                     }
                   }
                 },
@@ -172,11 +181,20 @@
                   events: [
                     {message:'plugin.externalLights.level',fn: function(lightNum, level){if( lightNum == 1){ return level > 0; } else{ return null; } } }
                   ],
-                  switch: function (state) {
-                    if (self.eventEmitter !== undefined){
-                      var level = 1;
-                      if (state==true) level = 0;
-                      self.eventEmitter.emit('plugin.externalLights.set', 1, level);
+                  switch: function (state) 
+                  {
+                    if (self.eventEmitter !== undefined)
+                    {
+                      if( state == true )
+                      {
+                        // Turn off
+                        self.eventEmitter.emit('plugin.externalLights.setOnOff', 1, false );
+                      }
+                      else
+                      {
+                        // Turn on to max
+                        self.eventEmitter.emit('plugin.externalLights.setOnOff', 1, true );
+                      }
                     }
                   }
                 },

--- a/src/plugins/new-ui/public/webcomponents/switches.html
+++ b/src/plugins/new-ui/public/webcomponents/switches.html
@@ -144,7 +144,7 @@
                   ],
                   switch: function (state) 
                   {
-                   if( state == true )
+                      if( state == true )
                       {
                         // Turn off
                         self.eventEmitter.emit('plugin.lights.setOnOff', false );


### PR DESCRIPTION
The LEDs and external lights now use integer steps to adjust the lights. In this pull request, they are set up to each have 6 steps:

Internal Lights:
```js
//  Settings:       = [ 0 .. 5 ]
self.levelMap        = [ 0, 80, 100, 130, 190, 255 ];
```

External Lights:
```js
//  Settings:       = [ 0 .. 5 ]
self.levelMap        = [ 0, 16, 32, 64, 128, 255 ];
```

The internal LED drivers are on a nonlinear driver now, so this allows you to specify a non-linear step range. You can add as many steps as you want by putting them into levelMap. The first and last should be 0 and 255 respectively, but there is nothing forcing that.