### PR TITLE
Fixing serialport. with 4.x the option for baud rate is called __baud…

### DIFF
--- a/src/system-plugins/platform-manager/platforms/beaglebone/boards/2x/bridge.js
+++ b/src/system-plugins/platform-manager/platforms/beaglebone/boards/2x/bridge.js
@@ -19,7 +19,7 @@ function Bridge()
   {
     serialPort = new SerialPort.SerialPort( uartPath,
     {
-      baudrate: uartBaud,
+      baudRate: uartBaud,
       parser: SerialPort.parsers.readline( '\r\n' )
     } );
 


### PR DESCRIPTION
fix baudRate option in serial port node modules