### PR TITLE
MJPG socket.io and http delivery work side by side

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,7 @@
 			"stopOnEntry": false,
 			"args": [],
 			"cwd": "${workspaceRoot}",
+			"preLaunchTask": null,
 			"runtimeExecutable": null,
 			"runtimeArgs": [
 				"--nolazy"
@@ -20,14 +21,15 @@
 				"DEV_MODE": "true",
 				"USE_MOCK": "true",
 				"CPU_MOCK": "123MOCK",
-				"GEO_MOCK": "true",
+				"GEO_MOCK": "false",
+				"MJPG_MOCK": "true",
 				"DEBUG": "bridge, mcu, cpu",
 				"port": 8080,
 				"configfile": "/tmp/rovconfig.json",
 				"plugins__ui-manager__selectedUI": "new-ui",
 				"pluginsDownloadDirectory": "/tmp/plugins"
 			},
-			"externalConsole": false,
+            "console": "internalConsole",			
 			"sourceMaps": false,
 			"outDir": null
 		},

--- a/src/plugins/mjpeg-video/index.js
+++ b/src/plugins/mjpeg-video/index.js
@@ -26,6 +26,13 @@ mjpegvideo.prototype.enumerateDevices = function enumerateDevices() {
       '-e',
       'true'
     ];
+
+  if (process.env.MJPG_MOCK === 'true') {
+    launch_options.push('-m');
+    launch_options.push('true');
+ //   launch_options.splice(1,0,'--debug-brk=15858');
+  }
+
   exec(launch_options.join(' '), { env: { DEBUG: process.env.DEBUG } }, function (error, stdout, stderr) {
     if (error) {
       deferred.reject(error);
@@ -46,9 +53,6 @@ mjpegvideo.prototype.enumerateDevices = function enumerateDevices() {
 };
 mjpegvideo.prototype.start = function start() {
   var self = this;
-  if (process.env.MJPG_MOCK === 'true') {
-    self.startCamera('/dev/video0');
-  } else {
     // self.deps.cockpit.on('plugin.mjpeg-video.start', function(device) {
     //   self.startCamera('/dev/' + device);
     //   self.connectVideoServer();
@@ -57,10 +61,10 @@ mjpegvideo.prototype.start = function start() {
       if (cameras && cameras.length > 0) {
         self.startVideoServer();
         self.connectVideoServer();  // log('Found cameras ' + JSON.stringify(cameras));
-                                    // self.deps.cockpit.emit("plugin.mjpeg-video.cameraInfo", cameras);
+        self.deps.cockpit.emit("plugin.mjpeg-video.cameraInfo", cameras);
       }
     });
-  }
+
 };
 mjpegvideo.prototype.connectVideoServer = function () {
   var self = this;
@@ -95,7 +99,7 @@ mjpegvideo.prototype.connectVideoServer = function () {
     });
   });
 };
-mjpegvideo.prototype.startVideoServer = function startCamera(device) {
+mjpegvideo.prototype.startVideoServer = function startVideoServer(device) {
   var launch_options = [
       'node',
       require.resolve('mjpeg-video-server')
@@ -106,6 +110,8 @@ mjpegvideo.prototype.startVideoServer = function startCamera(device) {
     launch_options.push('true');
     launch_options.push('-u');
     launch_options.push(':8090/?action=stream');
+  //  launch_options.splice(1,0,'--debug-brk=15858');
+    launch_options.splice(1,0,'--debug=15858');
   }
   const infinite = -1;
   log('Starting mjpeg-video-server ' + launch_options);

--- a/src/plugins/mjpeg-video/public/webcomponents/mjpeg-packet-video.html
+++ b/src/plugins/mjpeg-video/public/webcomponents/mjpeg-packet-video.html
@@ -1,0 +1,92 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
+
+<dom-module id="mjpeg-packet-video">
+    <style>
+    
+    #camera1 {
+      width: 100%;
+      max-height: 100%;
+    }
+    </style>
+    <template>
+    <div id="videocontainer" style="display:block; height:100%; width:100%; position:relative;" on-hover="">
+      <canvas id="camera1"></canvas>
+      <content></content>
+    </div>
+
+  </template>
+    <script>
+        (function() {
+            Polymer({
+                is: 'mjpeg-packet-video',
+                properties: {
+                    fps: {
+                        type: Number
+                    }
+                },
+                behaviors: [
+                Polymer.IronResizableBehavior
+                ],                
+                listeners: {
+                'iron-resize': '_onIronResize'
+                },     
+                _onIronResize: function(){
+                    var canvas = this.$.camera1;
+                    var style = window.getComputedStyle(this.$.videocontainer, null);
+                    canvas.width=parseInt(style.getPropertyValue('width'));
+                    canvas.height=parseInt(style.getPropertyValue('height'));
+                },           
+                attached: function() {
+                    this._drawCounter = 0;
+                    var self = this;
+                    var canvas = this.$.camera1;
+                    var image = new Image();
+                    setInterval(function() {
+                        self.set('fps', self._drawCounter)
+                        self._drawCounter = 0;
+                        if(canvas.width==0){
+                            self._onIronResize();
+                        }                        
+                    }, 1000);
+                    var style = window.getComputedStyle(self.$.videocontainer, null);
+                   // canvas.width=parseInt(style.getPropertyValue('width'));
+                   // canvas.height=parseInt(style.getPropertyValue('height'));
+                    this._drawFrame = function(frame) {
+
+                            var blob = new Blob([frame], {
+                                type: 'application/octet-binary'
+                            });
+                            var url = URL.createObjectURL(blob);
+                            var style = window.getComputedStyle(self.$.videocontainer, null);
+                            image.onload = function() {
+                                var vertialMargin=0;
+                                width = parseInt(style.getPropertyValue('width'));
+                                height = parseInt(style.getPropertyValue('height'));
+                                proportionalHeight = canvas.width * image.height / image.width;
+                                ctx = canvas.getContext('2d');
+                               // ctx.fillrect()
+                                if (proportionalHeight<canvas.height){
+                                    vertialMargin=(canvas.height-proportionalHeight)/2;
+                                }
+                                ctx.drawImage(image, 0, vertialMargin, canvas.width, proportionalHeight);
+                                
+                                self._drawCounter++;
+                                URL.revokeObjectURL(url);
+                            }
+                            image.src = url;
+                        
+                    }
+                },
+                stop: function() {},
+                ready: function() {},
+                /**
+                 * Takes a byte array for the jpeg image and displays it on screen
+                 */
+                append: function(frame) {
+                    this._drawFrame(frame);
+                }
+            });
+        }());
+    </script>
+</dom-module>

--- a/src/plugins/video/index.js
+++ b/src/plugins/video/index.js
@@ -8,7 +8,6 @@ function video(name, deps) {
   var self = this;
   this.deps.globalEventLoop.on('CameraRegistration', function (data) {
     self.cockpit.emit('CameraRegistration', data);
-    self.cockpit.emit('CameraRegistration2', {});
     console.log('### CameraRegistration');
   });
   this.cameras = {};

--- a/src/plugins/video/public/webcomponents/orov-video.html
+++ b/src/plugins/video/public/webcomponents/orov-video.html
@@ -2,12 +2,13 @@
 <link rel="import" href="../mjpeg-video-webcomponents/mjpeg-video.html">
 <link rel="import" href="../packet-video/packet-video.html">
 <link rel="import" href="../orov-behaviors/orov-behavior.html">
+<link rel="import" href="../mjpeg-video/mjpeg-packet-video.html">
 
 <dom-module name="orov-video">
   <style>
   </style>
   <template>
-    <template is="dom-if" if="{{displayPlayer(videoMimeType,'video/x-motion-jpeg')}}" iff="{{videoMimeType == 'video/x-motion-jpeg'}}">
+    <template is="dom-if" if="{{displayPlayer(videoMimeType,'video/x-motion-jpeg','http',_registerdConnection)}}" >
     <mjpeg-video id="camera1" border='1' style='width: 100%; height:100%'
       menuState='on'
       src='{{videoSource}}'
@@ -19,7 +20,13 @@
      </mjpeg-video>
     </template>
 
-    <template id="mp4template" is="dom-if" if="{{displayPlayer(videoMimeType,'video/mp4')}}" iff="{{videoMimeType == 'video/mp4'}}">
+    <template is="dom-if" if="{{displayPlayer(videoMimeType,'video/x-motion-jpeg','socket.io',_registerdConnection)}}" >
+    <mjpeg-packet-video id="camera1" border='1' style='width: 100%; height:100%'>
+      <content></content>
+     </mjpeg-packet-video>
+    </template>    
+
+    <template id="mp4template" is="dom-if" if="{{displayPlayer(videoMimeType,'video/mp4','socket.io',_registerdConnection)}}">
       <packet-video id="camera1" border='1' style='width: 100%; height:100%'
         menuState='on'
         src='{{videoSource}}'
@@ -45,7 +52,8 @@
           videoMimeType: {type:String},
           location: {type:String},
           showStats: {type:Boolean, value:function(){return false;}},
-          shortCircuit: {type:Boolean, value:function(){return false;}}
+          shortCircuit: {type:Boolean, value:function(){return false;}},
+          _registerdConnection: {type:Object, value:function(){return null;}}
         },
         behaviors: [namespace('behaviors').oROVStandard],
         detached: function(){
@@ -81,6 +89,7 @@
             self.videoMimeType=data.videoMimeType;
             self.framesPerSecond=data.framerate;
             self.videoSource = data.sourceAddress;
+            self.set('_registerdConnection',data);
           });
 
           //If we have segmented mp4 data streaming for this camera,
@@ -111,99 +120,26 @@
             }
           });
 
-          var image = new Image();
-          var imageSrc = '';
-          var tick = 2;
-
-          var draw;
-          var drawFrame;
-          var canvas;
-          var ctx;
-          var proportionalHeight;
-          var width;
-          var height;
-
-					var drawCounter = 0;
-
-					setInterval(function(){
-					//	console.log('FPS: ' + drawCounter);
-						drawCounter = 0;
-					}, 1000);
-
-					var img = new Image;
-					img.onload = function() {
-							URL.revokeObjectURL(this.src);
-							ctx.drawImage(img, 0, 0, canvas.width, proportionalHeight);
-							drawCounter++;
-					};
-
-					var loadImage = function(frame, canvas, proportionalHeight) {
-							var blob = new Blob([frame], {type: 'application/octet-binary'});
-							var url = URL.createObjectURL(blob);
-							img.src = url;
-					};
-          draw = function() {
-            var frame = buffer.pop();
-            if (frame ) {
-							drawFrame(frame);
-					}};
-					drawFrame = function(frame) {
-						if (frame.isDrawn == true) return;
-						frame.isDrawn = true;
-
-              if (!canvas || !width > 0 || !height > 0) {
-								var blob = new Blob([frame.data], {type: 'application/octet-binary'});
-								var url = URL.createObjectURL(blob);
-								image.onload = function() {
-
-									self.$$('#camera1').src = url; // set first frame
-									canvas = self.$$('#camera1').videocanvas;
-									var style = window.getComputedStyle(canvas.parentElement, null);
-									width = parseInt(style.getPropertyValue('width'));
-									height = parseInt(style.getPropertyValue('height'));
-									proportionalHeight = width * image.height / image.width;
-									ctx = canvas.getContext('2d');
-									self.$$('#camera1').stop();
-									self.$$('#camera1').isHidden = true;
-									URL.revokeObjectURL(url);
-								}
-								image.src = url;
-
-                
-              }            
-              if (canvas && (canvas.width== 0 || canvas.height == 0)) {
-                canvas.width = width;
-                canvas.height = height;
-              }
-							if (canvas && canvas.width > 0 && canvas.height > 0 ) 
-								loadImage(frame.data, canvas, proportionalHeight);
-            }
-
-					var mjpegDrawIntervall;
 
           emitter.on('x-motion-jpeg.data',function(frame){
             if (self.shortCircuit) {return;}            
             if (self.$$('#camera1')===null){
               return;
             }
-						// we draw the image via window.postMessage, this causes a context change and the
-						// image is drawn on the GPU thread;
-						window.postMessage({type: 'draw', data: frame, isDrawn: false}, '*', [frame]);
-          });
-					window.onmessage = function(message) {
-						if (message.data.type == 'draw') {
-							drawFrame(message.data);
-						}
-					}
-
+            self.$$('#camera1').append(frame);
+          })
         },
         _canvasChanged: function(){
           if (this.eventEmitter!==undefined){
             this.eventEmitter.emit('video.forward.canvas-changed',this.canvas);
           }
         },
-        displayPlayer(mimeType,playerType){
-          return mimeType==playerType;
+        displayPlayer(mimeType,playerType,connection,registeredConnection){
+          if (registeredConnection == null){
+            return false;
+          }
+          var connectionMatch=connection==null?true:registeredConnection.connectionType==connection;
+          return ((mimeType==playerType) && connectionMatch);
         }
     });
   </script>


### PR DESCRIPTION
* Refactored the socket.io based mjpeg player from the video.js to a stand alone web component.  
* Removed some of the code complexity around worker processes as it was not clear that it was  actually fully implemented and giving the desired outcome.
* Fixed some key code that was commented out in the camera registration message flow
* Made sure that http based mjpeg cameras only load when http sources exist

Performance:
By disabling and re-enabling the 30fps 640x480 stream I saw a 10% cpu hit in the 'program' category.  None of its routines are in the top 10.