### PR TITLE
User can dump crash report data

### DIFF
--- a/src/plugins/about/README.md
+++ b/src/plugins/about/README.md
@@ -1,0 +1,1 @@
+This plugin enables the ability to report and dump information about the ROV that is useful in debugging issues.

--- a/src/plugins/about/about.ejs
+++ b/src/plugins/about/about.ejs
@@ -54,7 +54,7 @@ template._dumpReport = function(){
     template.cockpitEventEmitter.emit("plugin.about.dumpReport",function(report){
         var result = JSON.parse(report);
         result.browserString=navigator.userAgent;
-        result.timestamp=DateTime.now().toString();
+        result.timestamp=Date.now().toString();
         template.cockpitEventEmitter.emit("plugin.host-diagnostics.getbrowserlogs",function(logs){
             result.console=logs;
             report = JSON.stringify(result);

--- a/src/plugins/about/about.ejs
+++ b/src/plugins/about/about.ejs
@@ -1,0 +1,69 @@
+
+<style>
+    paper-button {
+
+    }
+    paper-material{
+        margin-bottom:10px;
+        background-color:white;
+    }
+    .back-surface {
+        background-color:#f9f2f2;
+    }
+</style>
+<div class="back-surface">
+<paper-material  elevation="1">
+<fieldset>
+<legend>Support:</legend>    
+<paper-button raised id="dumpReport" on-tap="_dumpReport">Dump System Report</paper-button>
+</fieldset>
+</paper-material>
+<script>
+var template = $('#t')[0];
+var saveData = (function () {
+    var a = document.createElement("a");
+    document.body.appendChild(a);
+    a.style = "display: none";
+    return function (data, fileName) {
+        var json = JSON.stringify(data),
+            blob = new Blob([json], {type: "octet/stream"}),
+            url = window.URL.createObjectURL(blob);
+        a.href = url;
+        a.download = fileName;
+        a.click();
+        window.URL.revokeObjectURL(url);
+    };
+}());
+
+function formatDate(d) {
+
+  var dd = d.getDate()
+  if ( dd < 10 ) dd = '0' + dd
+
+  var mm = d.getMonth()+1
+  if ( mm < 10 ) mm = '0' + mm
+
+  var yy = d.getFullYear() % 100
+  if ( yy < 10 ) yy = '0' + yy
+
+  return ""+yy+mm+dd
+}
+
+
+template._dumpReport = function(){
+    template.cockpitEventEmitter.emit("plugin.about.dumpReport",function(report){
+        var result = JSON.parse(report);
+        result.browserString=navigator.userAgent;
+        result.timestamp=DateTime.now().toString();
+        template.cockpitEventEmitter.emit("plugin.host-diagnostics.getbrowserlogs",function(logs){
+            result.console=logs;
+            report = JSON.stringify(result);
+            console.dir(JSON.parse(report));
+            saveData(result,`rovCrashReportingDump${Date.now().toString()}.json`)
+        });
+
+    });
+}
+</script>
+</div>
+

--- a/src/plugins/about/index.js
+++ b/src/plugins/about/index.js
@@ -1,0 +1,22 @@
+const log = require('Debug')('log:about');
+const trace = require('Debug')('trace:about');
+const debug = require('Debug')('debug:about');
+
+const Listener = require('Listener');
+
+class About {
+
+    constructor(name, deps) {
+
+        log("Loaded About plugin");
+
+        this.globalBus = deps.globalEventLoop; // This is the server-side messaging bus. The MCU sends messages to server plugins over this
+        this.cockpitBus = deps.cockpit; // This is the server<->client messaging bus. This is how the server talks to the browser
+        var self = this;
+    }
+
+}
+
+module.exports = function(name, deps) {
+    return new About(name, deps);
+};

--- a/src/plugins/about/index.js
+++ b/src/plugins/about/index.js
@@ -2,7 +2,45 @@ const log = require('Debug')('log:about');
 const trace = require('Debug')('trace:about');
 const debug = require('Debug')('debug:about');
 
+const bluebird = require('bluebird');
 const Listener = require('Listener');
+const execFile = require('child_process').execFile;
+//bluebird.promisify(execAsync);
+
+
+//private functions
+
+
+function execAsync(command,args){
+    return new bluebird(function(resolve,reject){
+        return execFile(command,args,function(error,stdout,stderr){
+            if (error){
+                 resolve(JSON.stringify(error));
+            }
+            resolve(stdout,stderr);
+        })
+    })
+}
+
+function getpsAux() {
+    return execAsync('ps',['aux']);
+}
+
+function getFree() {
+    return execAsync('free',[]);
+}
+
+function getDF() {
+    return execAsync('df',[]);
+}
+
+function getJournalCTL() {
+    return execAsync('journalctl',['-o json']);
+}
+
+function getROVImageVersion(){
+    return execAsync('cat',['/ROV-Suite-version'])
+}
 
 class About {
 
@@ -12,8 +50,81 @@ class About {
 
         this.globalBus = deps.globalEventLoop; // This is the server-side messaging bus. The MCU sends messages to server plugins over this
         this.cockpitBus = deps.cockpit; // This is the server<->client messaging bus. This is how the server talks to the browser
+        this.loopDelays = [];
+        this.notifications = [];
+        this.deps=deps;
         var self = this;
+
+        this.listeners = {
+            settings: new Listener(self.globalBus, 'settings-change.about', true, function(settings) {
+                self.settings = settings.about;
+            }),
+
+            loopDelays: new Listener(self.globalBus, 'plugin.host-diagnostics.loopDelay', false, function(delay){
+                self.loopDelays.push({timestamp:Date.now(),delay:delay});
+                if (self.loopDelays.length==99){
+                    self.globalBus.emit('notification','The ROV embedded computer has been struggling to process messages.');
+                }
+                if (self.loopDelays.length==100){
+                    self.loopDelays.shift();
+                }
+            }),
+
+            notifications: new Listener(self.globalBus, 'plugin.notification.all-notices', false, function(notices){
+                self.notifications=notices;
+            }),
+
+            dumpReport: new Listener(self.cockpitBus, 'plugin.about.dumpReport', false, function(callback) {
+                var report={}
+                getpsAux()
+                .then (function(stdout,stderr){
+                    report.ps=stdout;
+                    trace("ps:"+stdout);
+                })
+                .then (function(){
+                    report.loopDelays=self.loopDelays;
+                    report.notifications = self.notifications;
+                    report.config=self.deps.config;
+                })
+                .then (getFree)
+                .then (function(stdout,stderr){
+                    report.free = stdout;
+                })
+                .then (getDF)
+                .then (function(stdout,stderr){
+                    report.df = stdout;
+                })   
+                .then (getJournalCTL)
+                .then (function(stdout,stderr){
+                    report.journalctl = stdout;
+                })     
+                .then (getROVImageVersion)
+                .then (function(stdout,stderr){
+                    report.rovImageVersion = stdout;
+                })                                          
+                .then (function(){
+                    callback(JSON.stringify(report));
+                })                
+            })
+        }
     }
+
+    start() {
+        // Enable the listeners!
+        this.listeners.settings.enable();
+        this.listeners.loopDelays.enable();
+        this.listeners.notifications.enable();
+        this.listeners.dumpReport.enable();
+    }
+
+    // This is called when the plugin is disabled
+    stop() {
+        // Disable listeners
+        this.listeners.settings.disable();
+        this.listeners.loopDelays.disable();
+        this.listeners.notifications.disable();        
+        this.listeners.dumpReprot.disable();
+    }    
 
 }
 

--- a/src/plugins/about/index.js
+++ b/src/plugins/about/index.js
@@ -1,12 +1,10 @@
-const log = require('Debug')('log:about');
-const trace = require('Debug')('trace:about');
-const debug = require('Debug')('debug:about');
+const log = require('debug')('log:about');
+const trace = require('debug')('trace:about');
+const debug = require('debug')('debug:about');
 
 const bluebird = require('bluebird');
 const Listener = require('Listener');
 const execFile = require('child_process').execFile;
-//bluebird.promisify(execAsync);
-
 
 //private functions
 

--- a/src/plugins/about/public/js/about.js
+++ b/src/plugins/about/public/js/about.js
@@ -1,0 +1,23 @@
+(function(window)
+{
+    'use strict';
+    class about
+    {
+        constructor(cockpit)
+        {
+            console.log('System About Plugin running');
+            var self = this;
+            this.cockpit = cockpit;
+            this.rov = cockpit.rov;
+
+            this.cockpit.on('plugin.about.dumpReport', function(callback) {
+                self.rov.emit('plugin.about.dumpReport',callback);
+            })
+        }
+    }
+
+    // Add plugin to the window object and add it to the plugins list
+    var plugins = namespace('plugins');
+    plugins.about = about;
+    window.Cockpit.plugins.push(plugins.about);
+}(window));

--- a/src/plugins/host-diagnostics/public/js/host-diagnostics.js
+++ b/src/plugins/host-diagnostics/public/js/host-diagnostics.js
@@ -1,5 +1,6 @@
 (function (window, $, undefined) {
   'use strict';
+  var consoleRecorder = [];
   var HostDiagnostics;
   HostDiagnostics = function HostDiagnostics(cockpit) {
     console.log('Loading HostDiagnostics plugin in the browser.');
@@ -18,6 +19,12 @@
     this.cockpit.rov.onAny(function () {
       self.rov_events++;
     });
+
+    this.cockpit.on("plugin.host-diagnostics.getbrowserlogs",function(callback){
+      callback(consoleRecorder);
+    });
+
+
     setInterval(function () {
       self.cockpit.emit('plugin.host-diagnostics.event-counts', {
         cockpit: self.cockpit_events,
@@ -42,4 +49,33 @@
   HostDiagnostics.prototype.toggleDisplay = function toggleDisplay() {
   };
   window.Cockpit.plugins.push(HostDiagnostics);
+
+
+function takeOverConsole(){
+    var console = window.console
+    if (!console) return
+    function intercept(method){
+        var original = console[method]
+        console[method] = function(){
+            // do sneaky stuff
+            consoleRecorder.push({timestamp:Date.now(),msg:Array.prototype.slice.apply(arguments).join(' ')});
+            if (consoleRecorder.length>500){
+              consoleRecorder.shift();
+            }
+            if (original.apply){
+                // Do this for normal browsers
+                original.apply(console, arguments)
+            }else{
+                // Do this for IE
+                var message = Array.prototype.slice.apply(arguments).join(' ')
+                original(message)
+            }
+        }
+    }
+    var methods = ['log', 'warn', 'error']
+    for (var i = 0; i < methods.length; i++)
+        intercept(methods[i])
+}
+takeOverConsole();
+  
 }(window, jQuery));

--- a/src/plugins/host-diagnostics/public/js/host-diagnostics.js
+++ b/src/plugins/host-diagnostics/public/js/host-diagnostics.js
@@ -1,6 +1,6 @@
 (function (window, $, undefined) {
   'use strict';
-  var consoleRecorder = [];
+
   var HostDiagnostics;
   HostDiagnostics = function HostDiagnostics(cockpit) {
     console.log('Loading HostDiagnostics plugin in the browser.');
@@ -19,11 +19,6 @@
     this.cockpit.rov.onAny(function () {
       self.rov_events++;
     });
-
-    this.cockpit.on("plugin.host-diagnostics.getbrowserlogs",function(callback){
-      callback(consoleRecorder);
-    });
-
 
     setInterval(function () {
       self.cockpit.emit('plugin.host-diagnostics.event-counts', {
@@ -50,32 +45,5 @@
   };
   window.Cockpit.plugins.push(HostDiagnostics);
 
-
-function takeOverConsole(){
-    var console = window.console
-    if (!console) return
-    function intercept(method){
-        var original = console[method]
-        console[method] = function(){
-            // do sneaky stuff
-            consoleRecorder.push({timestamp:Date.now(),msg:Array.prototype.slice.apply(arguments).join(' ')});
-            if (consoleRecorder.length>500){
-              consoleRecorder.shift();
-            }
-            if (original.apply){
-                // Do this for normal browsers
-                original.apply(console, arguments)
-            }else{
-                // Do this for IE
-                var message = Array.prototype.slice.apply(arguments).join(' ')
-                original(message)
-            }
-        }
-    }
-    var methods = ['log', 'warn', 'error']
-    for (var i = 0; i < methods.length; i++)
-        intercept(methods[i])
-}
-takeOverConsole();
   
 }(window, jQuery));

--- a/src/plugins/host-diagnostics/public/js/logcapture.js
+++ b/src/plugins/host-diagnostics/public/js/logcapture.js
@@ -1,0 +1,47 @@
+(function (window, $, undefined) {
+  var consoleRecorder = [];    
+
+  var logcapture;
+  logcapture = function logcapture(cockpit) {
+      this.cockpit = cockpit;
+  }
+
+  logcapture.prototype.listen = function listen() {
+    this.cockpit.on("plugin.host-diagnostics.getbrowserlogs",function(callback){
+      callback(consoleRecorder);
+    });
+  }
+  window.Cockpit.plugins.push(logcapture);
+
+console.log("Developers, you will want to `blackbox` the logcapture.js script to get the originating line numbers in the chrome console.");
+function takeOverConsole(){
+    var console = window.console
+    if (!console) return
+    function intercept(method){
+        var original = console[method]
+        console[method] = function(){
+            consoleRecorder.push({timestamp:Date.now(),msg:Array.prototype.slice.apply(arguments).join(' '),stack:(new Error()).stack});
+            if (consoleRecorder.length>500){
+              consoleRecorder.shift();
+            }
+            if (original.apply){
+                // Do this for normal browsers
+                // This script captures writes to the console log/warn/error for reporting, which means
+                // the line number refrenced of the original caller in the Chrome console gets replace
+                // with this line.  You can right click on this file in dev tools and choose "blackbox" script
+                // and the line numbers will go back to what you expect.
+                return original.apply(console, arguments)
+            }else{
+                // Do this for IE
+                var message = Array.prototype.slice.apply(arguments).join(' ')
+                return original(message)
+            }
+        }
+    }
+    var methods = ['log', 'warn', 'error']
+    for (var i = 0; i < methods.length; i++)
+        intercept(methods[i])
+}
+takeOverConsole();
+  
+}(window, jQuery));

--- a/src/system-plugins/platform-manager/platforms/mock/boards/mock3000/bridge.js
+++ b/src/system-plugins/platform-manager/platforms/mock/boards/mock3000/bridge.js
@@ -1,5 +1,6 @@
 var EventEmitter = require('events').EventEmitter;
 var debug = require('debug')('bridge');
+var trace = require('debug')('trace:bridge');
 
 
 // Encoding helper functions
@@ -64,6 +65,13 @@ function Bridge()
         
         break;
       }
+
+      case 'ping': 
+      {
+        bridge.emitStatus(`pong:${commandParts[1]}`);
+        trace(`pong:${commandParts[1]}`);
+        break;
+      }      
 
       case 'lights_tpow': 
       {


### PR DESCRIPTION
This feature adds the ability for the user to dump the state of the ROV for the purpose of submitting a bug or request for help.

- [x] Dumps ps aux
- [x] Dumps cockpit node process loop delay
- [ ] Dumps browser process loop delay *Deferring*
- [x] Dumps `free` command output
- [x] Dumps `df` command output
- [x] Dumps rovConfig
- [x] Dumps notification database
- [x] Dumps journalctl
- [x] Dumps all errors in browser console
- [x] Dumps browser string
- [x] Dumps ROV image version
- [ ] Test on bbb. Some of the calls require linux to validate.
