### PR TITLE
Checkes firmware versions does not trigger upgrade

### DIFF
--- a/src/system-plugins/platform-manager/platforms/beaglebone/boards/2x/statemachine.js
+++ b/src/system-plugins/platform-manager/platforms/beaglebone/boards/2x/statemachine.js
@@ -43,7 +43,7 @@ module.exports = function( board )
     {
         var self = this;
 
-        status( "Checking ESCs...", "InProgress" );
+        status( "Checking ESCs...", "Examining" );
 
         // Check to see if ESCs have been flashed before by testing the existence of esc.conf
         fs.statAsync( escConfPath )
@@ -66,6 +66,7 @@ module.exports = function( board )
         var self = this;
 
         status( "Flashing ESCs...", "InProgress" );
+        this.data.flashingAttemped = true;
 
         // First, disconnect the bridge
         self.board.bridge.close();
@@ -101,7 +102,7 @@ module.exports = function( board )
     {
         var self = this;
 
-        status( "Checking if firmware already built...", "InProgress" );
+        status( "Checking if firmware already built...", "Examining" );
 
         // Check to see if ESCs have been flashed before by testing the existence of esc.conf
         fs.statAsync( mcuBinPath )
@@ -122,7 +123,7 @@ module.exports = function( board )
     function buildFirmwareHandler(event, from, to)
     {
         status( "Building firmware...", "InProgress" );
-
+        this.data.flashingAttemped = true;
         var self = this;
 
         // Execute the build firmware script
@@ -143,7 +144,7 @@ module.exports = function( board )
 
     function getHashHandler(event, from, to)
     {
-        status( "Fetching firmware hash...", "InProgress" );
+        status( "Fetching firmware hash...", "Examining" );
 
         var self = this;
 
@@ -182,7 +183,7 @@ module.exports = function( board )
     function flashMCUHandler(event, from, to)
     {
         status( "Flashing MCU firmware...", "InProgress" );
-
+        this.data.flashingAttemped = true;
         var self = this;
 
         // Execute the build firmware script
@@ -203,7 +204,7 @@ module.exports = function( board )
 
     function verifyVersionHandler(event, from, to)
     {
-        status( "Checking current firmware against latest...", "InProgress" );
+        status( "Checking current firmware against latest...", "Examining" );
 
         var self = this;
 
@@ -287,13 +288,17 @@ module.exports = function( board )
     function completeHandler(event, from, to)
     {
         status( "Firmware up to date!", "Complete" );
-        notify( "Firmware update applied");
+        if (this.data.flashingAttemped){
+            notify( "Firmware update applied");
+        }
+        this.data.flashingAttemped = false;
     }
 
     function failHandler(event, from, to)
     {
         status( "Firmware update failed!", "Failed" );
         notify( "Firmware update failed");
+        this.data.flashingAttemped = false;
     }
 
     function eFailHandler(event, from, to, msg) 

--- a/src/system-plugins/software-update-alert/public/webcomponents/orov-software-update-router.html
+++ b/src/system-plugins/software-update-alert/public/webcomponents/orov-software-update-router.html
@@ -24,6 +24,8 @@
               status.progress;
 
               switch(status.progress){
+                  case "Examining":
+                  break;
                   case "InProgress":
                     self.set('updateInProgress',true);
                     self.set('applet','_updates');


### PR DESCRIPTION
This adds a new lifecycle for the firmware upgrades called “Examining”.  When examining if the firmware needs to be update, the UI will ignore those messages.  Only when the firmware is actually being build/upgraded will the system switch to the applying updates screen.