### PR TITLE
fixed openrov/openrov-software#626

### DIFF
--- a/src/static/js/libs/gamepad.js
+++ b/src/static/js/libs/gamepad.js
@@ -582,7 +582,13 @@
       console.log('Not supposed to go here!');
       return;  // should not happen
     }
-    if (gamepads.length !== this.gamepads.length) {
+    gamepads.nonNulllength = 0;
+    for (i = 0; i < gamepads.length; i++) {
+      if (gamepads[i]!==null){
+        gamepads.nonNulllength++;
+      }
+    }
+    if (gamepads.nonNulllength !== this.gamepads.length) {
       var gamepad, i;
       for (i = 0; i < gamepads.length; i++) {
         gamepad = gamepads[i];
@@ -591,7 +597,7 @@
         }
       }
       for (i = 0; i < this.gamepads.length; i++) {
-        if (typeof this.gamepads[i] !== 'undefined' && typeof gamepads[i] === 'undefined') {
+        if (typeof this.gamepads[i] !== 'undefined' && !(gamepads[i])) {
           this._disconnect(this.gamepads[i]);
         }
       }


### PR DESCRIPTION
This adjusts for the changes in the gamepad API which include the getGamePads() always returning a fixed set of 4 entries with nulls (vs only populated values).