### PR TITLE
Feature/beacon

### DIFF
--- a/src/plugins/blackbox/public/js/blackbox.js
+++ b/src/plugins/blackbox/public/js/blackbox.js
@@ -637,23 +637,27 @@
     .then(function (session) {
       session_record = session;
       var sort = 0;
+      var promiseChain = Promise.resolve();
       self.idb.telemetry_events
         .where('sessionID').equalsIgnoreCase(options.sessionID)
         .filter(function (item) {
           return item.event == 'x-h264-video.data';
         })
         .each(function(videoItem){
-          return new Promise(function(resolve,reject){
-            save(new Uint8Array(videoItem.data),function(){
-              resolve();
-            }); 
+          promiseChain = promiseChain.then(function(){
+            return new Promise(function(resolve,reject){
+              save(new Uint8Array(videoItem.data),function(){
+                resolve();
+              }); 
+            })
           })
-
+        })
+        .then(function(){
+          return promiseChain;
         })
         .then(function(){
           alert("Export Complete");
         })
-
     });
   }
 

--- a/src/system-plugins/platform-manager/platforms/mock/boards/mock3000/bridge.js
+++ b/src/system-plugins/platform-manager/platforms/mock/boards/mock3000/bridge.js
@@ -38,7 +38,9 @@ function Bridge()
     vout:         5.0,
     iout:         2.0,
     bt1i:         0.0,
-    bt2i:         0.0
+    bt2i:         0.0,
+    baro_p:       0,
+    baro_t:       0.0
   }
 
   // IMU State
@@ -68,6 +70,11 @@ function Bridge()
     depthOffset:  0,
     temperature:  0,
     pressure:     0
+  }
+
+  var baraometer = {
+    temperature: 0,
+    pressure:    0
   }
 
   bridge.depthHoldEnabled   = false;
@@ -493,6 +500,12 @@ function Bridge()
 
     cb.vout = cb.brdv;
 
+    //Generate internal pressure values
+    cb.baro_p = 30000000;
+    var num = Math.floor(Math.random()*1000000) + 1; // this will get a number between 1 and 99;
+    num *= Math.floor(Math.random()*2) == 1 ? 1 : -1; // this will add minus sign in 50% of cases
+    cb.baro_p += num;
+
     // Create result string
     var result = "";
     result += 'BT2I:' + cb.bt2i + ';';
@@ -501,6 +514,8 @@ function Bridge()
     result += 'vout:' + cb.vout + ';';
     result += 'iout:' + cb.iout + ';';
     result += 'time:' + cb.time + ';';
+    result += 'baro_p:' + cb.baro_p + ';';
+    result += 'baro_t:' + cb.baro_t + ';';
 
     // Emit status update
     bridge.emit( 'status', reader.parseStatus( result ) );

--- a/src/system-plugins/rov-beacon/beacon.js
+++ b/src/system-plugins/rov-beacon/beacon.js
@@ -1,0 +1,73 @@
+"use strict";
+const dgram = require('dgram');
+const EventEmitter = require('events');
+class Beacon extends EventEmitter{
+
+    constructor (options){
+        if(!options){
+            options = {}
+        }
+        super();
+        this.port = options.port || 8088;
+        this.broadcastAddress = options.broadcastAddress || '192.168.1.255';//;'230.185.192.108';
+        this.beaconRate = options.beaconRate || 3000;
+       
+    }
+
+    broadcast(messageFn) {
+        var self = this;
+        this.server = dgram.createSocket('udp4');
+        let server = this.server;
+        server.on('listening', () => {
+        var address = server.address();
+            server.setBroadcast(true)
+       //     server.setMulticastTTL(128);
+       //     server.addMembership( self.broadcastAddress);   
+        });
+
+        this.beaconInterval = setInterval(broadcastNew, this.beaconRate);
+
+        function broadcastNew() {
+            var message = new Buffer(JSON.stringify(messageFn()));
+            server.send(message, 0, message.length, self.port,  self.broadcastAddress);
+        }
+
+        server.bind();
+
+    }
+
+    listen () {
+        var self=this;
+        this.client = dgram.createSocket('udp4');
+        let client = this.client;
+        
+        client.on('listening', function () {
+            var address = client.address();
+            console.log('UDP Client listening on ' + address.address + ":" + address.port);
+            client.setBroadcast(true)
+      //      client.setMulticastTTL(128); 
+      //      client.addMembership( self.broadcastAddress);
+        });
+
+        client.on('message', function (message, remote) {   
+            self.emit("deviceAnnouncement",{remoteAddress:remote.address,remotePort:remote.port,data:message})
+        });
+
+        client.bind(this.port);
+
+    }
+
+    stop () {
+        clearInterval(this.beaconInterval);
+        if (this.server){
+            this.server.close();
+        }
+        if (this.client){
+            this.client.close();
+        }
+    }
+}
+
+module.exports = function(options){
+    return new Beacon(options)
+};

--- a/src/system-plugins/rov-beacon/index.js
+++ b/src/system-plugins/rov-beacon/index.js
@@ -1,0 +1,74 @@
+'use strict';
+const beaconRate = 5000;
+const ignorePressureChangeThreshold = 100000;
+class RovBeacon{
+    constructor(name,deps){
+     this.state={
+         name: require('os').hostname(),
+         //model:'trident',  //TODO: Add model detection
+         battery:.7
+     };
+     this.beacon = null;
+     this.bus = deps.globalEventLoop;
+
+     this._lastIntPressureReading = {time:0,p:0,t:0};
+    }
+
+    start() {
+     this.beacon = require('./beacon.js')({beaconRate});
+     this.beacon.broadcast(this._genBeaconMessage.bind(this));
+     this._listenForStateChanges();
+    }
+
+    stop(){
+     this.beacon.stop();
+     this._stopListenForStateChanges()
+    }
+
+    _genBeaconMessage(){
+        this.state.exp=beaconRate*2; //Set the expeiration for this to 2X the broadcast rate.
+        return this.state;
+    }
+
+    _listenForStateChanges(){
+      this.bus.on('mcu.status',this._processMCUStatus.bind(this))
+    }
+
+    _stopListenForStateChanges(){
+      this.bus.off('mcu.status',this._processMCUStatus.bind(this))
+    }
+
+    _computerPressureTrend(currentpressure,currenttemp){
+        //TODO: Do we need to enhance for temperature compensation?
+        if (this._lastIntPressureReading.p> (currentpressure+ignorePressureChangeThreshold)) {
+            return this._lastIntPressureReading.p-currentpressure;
+        }
+        if (this._lastIntPressureReading.p< ( currentpressure-ignorePressureChangeThreshold)){
+            return this._lastIntPressureReading.p-currentpressure;
+        }
+        return 0
+    }
+
+    _processMCUStatus(status){
+        for (var data in status) {
+            switch (data) {
+                case 'baro_p' : 
+                    //TODO: Confirm the value units of baro_p
+                    //https://gitlab.com/openrov/RIOT/blob/openrov/apps/trident/CMPL3115A2.cpp#L98
+                    this.state.intPressure_mb=status["baro_p"];
+                    //TODO: Does this need to be smoothed over time?
+                    this.state.intPressureRate=this._computerPressureTrend(this.state.intPressure_mb,status['baro_t']);
+                    this._lastIntPressureReading = {time: Date.now(), p:this.state.intPressure_mb, t:status['baro_t']};
+                break;
+                case 'vout' :
+                  this.state.battery = status['vout'];
+                break;                
+            }
+        }
+    }
+
+}
+
+module.exports = function (name, deps) {
+  return new RovBeacon(name, deps);
+};


### PR DESCRIPTION
Adds a system level plugin that will broadcast details of the ROV to the local subnet every 5 seconds.
Details include
* Hostname
* Battery Voltage
* Internal Pressure
* Rate of Pressure Change
* IP address of unit

This works for all series TOVs and gracefully degrades by not sending details if they are not available.

This is intended to provide a means for clients to dynamically discover the ROV when it is on the same subnet (such aa a router or when the phone is used as a tethering device).

Clients that listen to this UDP beacon don’t have to actually establish a connection to the ROV report on the details listed above.

