### PR TITLE
Moved i2c lib as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "findit": "^2.0.0",
     "forever-monitor": "",
     "fs-extra": "",
-    "i2c": "",
     "javascript-state-machine": "^2.3.5",
     "jquery-file-upload-middleware": "",
     "json-schema-defaults": "^0.2.0",
@@ -82,6 +81,7 @@
     "tap": "^6.3.2"
   },
   "optionalDependencies": {
-    "fsevents": "^1.0.14"
+    "fsevents": "^1.0.14",
+    "i2c": ""
   }
 }


### PR DESCRIPTION
This library only works on linux as a platform. Moving to optional so that npm install works on all platforms.